### PR TITLE
[feat] 2차 세미나 과제

### DIFF
--- a/week2/practice/.gitignore
+++ b/week2/practice/.gitignore
@@ -1,0 +1,39 @@
+HELP.md
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### IntelliJ IDEA ###
+application.yml
+
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/

--- a/week2/practice/src/main/java/org/sopt/practice/controller/MemberController.java
+++ b/week2/practice/src/main/java/org/sopt/practice/controller/MemberController.java
@@ -19,7 +19,8 @@ public class MemberController {
 
     @PostMapping
     public ResponseEntity createMember(
-            @RequestBody MemberCreateDto memberCreate) {
+            @RequestBody MemberCreateDto memberCreate
+    ) {
         return ResponseEntity.created(URI.create(memberService.createMember(memberCreate))).build();
     }
 

--- a/week2/practice/src/main/java/org/sopt/practice/controller/MemberController.java
+++ b/week2/practice/src/main/java/org/sopt/practice/controller/MemberController.java
@@ -1,0 +1,46 @@
+package org.sopt.practice.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.practice.service.MemberService;
+import org.sopt.practice.service.dto.MemberCreateDto;
+import org.sopt.practice.service.dto.MemberFindDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/members")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping
+    public ResponseEntity createMember(
+            @RequestBody MemberCreateDto memberCreate) {
+        return ResponseEntity.created(URI.create(memberService.createMember(memberCreate))).build();
+    }
+
+    @GetMapping("/{memberId}")
+    public ResponseEntity<MemberFindDto> findMemberById(
+            @PathVariable Long memberId
+    ) {
+        return ResponseEntity.ok(memberService.findMemberById(memberId));
+    }
+
+    @DeleteMapping("/{memberId}")
+    public ResponseEntity deleteMember(
+            @PathVariable Long memberId
+    ) {
+        memberService.deleteMemberById(memberId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<List<MemberFindDto>> findAllMembers() {
+        return ResponseEntity.ok(memberService.findAllMembers());
+    }
+
+}

--- a/week2/practice/src/main/java/org/sopt/practice/controller/TestController.java
+++ b/week2/practice/src/main/java/org/sopt/practice/controller/TestController.java
@@ -1,0 +1,19 @@
+package org.sopt.practice.controller;
+
+import org.sopt.practice.controller.dto.ApiResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class TestController {
+
+    @GetMapping("/test")
+    public String test() {
+        return "1차 세미나 테스트 API 입니다!";
+    }
+
+    @GetMapping("/test/json")
+    public ApiResponse testJson() {
+        return ApiResponse.create("1차 세미나 API - JSON");
+    }
+}

--- a/week2/practice/src/main/java/org/sopt/practice/controller/dto/ApiResponse.java
+++ b/week2/practice/src/main/java/org/sopt/practice/controller/dto/ApiResponse.java
@@ -1,0 +1,14 @@
+package org.sopt.practice.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ApiResponse {
+    String content;
+
+    public static ApiResponse create(String content) {
+        return new ApiResponse(content);
+    }
+}

--- a/week2/practice/src/main/java/org/sopt/practice/domain/Member.java
+++ b/week2/practice/src/main/java/org/sopt/practice/domain/Member.java
@@ -1,0 +1,37 @@
+package org.sopt.practice.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Member {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    private Part part;
+
+    private int age;
+
+    @Builder
+    public Member(String name, Part part, int age) {
+        this.name = name;
+        this.part = part;
+        this.age = age;
+    }
+
+    public static Member create(String name, Part part, int age) {
+        return Member.builder()
+                .name(name)
+                .part(part)
+                .age(age)
+                .build();
+    }
+}

--- a/week2/practice/src/main/java/org/sopt/practice/domain/Part.java
+++ b/week2/practice/src/main/java/org/sopt/practice/domain/Part.java
@@ -1,0 +1,11 @@
+package org.sopt.practice.domain;
+
+public enum Part {
+
+    IOS,
+    SERVER,
+    ANDROID,
+    WEB,
+    PLAN,
+    DESIGN
+}

--- a/week2/practice/src/main/java/org/sopt/practice/repository/MemberRepository.java
+++ b/week2/practice/src/main/java/org/sopt/practice/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.practice.repository;
+
+import org.sopt.practice.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/week2/practice/src/main/java/org/sopt/practice/repository/MemberRepository.java
+++ b/week2/practice/src/main/java/org/sopt/practice/repository/MemberRepository.java
@@ -1,7 +1,14 @@
 package org.sopt.practice.repository;
 
+import jakarta.persistence.EntityNotFoundException;
 import org.sopt.practice.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    default Member findByIdOrThrow(Long id) {
+        return findById(id).orElseThrow(
+                () -> new EntityNotFoundException("ID에 해당하는 사용자가 존재하지 않습니다.")
+        );
+    }
 }

--- a/week2/practice/src/main/java/org/sopt/practice/service/MemberService.java
+++ b/week2/practice/src/main/java/org/sopt/practice/service/MemberService.java
@@ -1,0 +1,49 @@
+package org.sopt.practice.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.sopt.practice.domain.Member;
+import org.sopt.practice.repository.MemberRepository;
+import org.sopt.practice.service.dto.MemberCreateDto;
+import org.sopt.practice.service.dto.MemberFindDto;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional //db에 변경사항이 생길 때 사용
+    public String createMember(MemberCreateDto memberCreate) {
+
+        Member member = Member.create(memberCreate.name(), memberCreate.part(), memberCreate.age());
+        memberRepository.save(member);
+        return member.getId().toString();
+    }
+
+    public MemberFindDto findMemberById(Long memberId) {
+        return MemberFindDto.of(memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("ID에 해당하는 사용자가 존재하지 않습니다.")
+        ));
+    }
+
+    @Transactional
+    public void deleteMemberById(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("ID에 해당하는 사용자가 존재하지 않습니다."));
+        memberRepository.delete(member);
+    }
+
+    public List<MemberFindDto> findAllMembers() {
+        List<Member> members = memberRepository.findAll();
+        return members.stream()
+                .map(MemberFindDto::of)
+                .collect(Collectors.toList());
+    }
+}

--- a/week2/practice/src/main/java/org/sopt/practice/service/MemberService.java
+++ b/week2/practice/src/main/java/org/sopt/practice/service/MemberService.java
@@ -28,16 +28,12 @@ public class MemberService {
     }
 
     public MemberFindDto findMemberById(Long memberId) {
-        return MemberFindDto.of(memberRepository.findById(memberId)
-                .orElseThrow(() -> new EntityNotFoundException("ID에 해당하는 사용자가 존재하지 않습니다.")
-        ));
+        return MemberFindDto.of(memberRepository.findByIdOrThrow(memberId));
     }
 
     @Transactional
     public void deleteMemberById(Long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new EntityNotFoundException("ID에 해당하는 사용자가 존재하지 않습니다."));
-        memberRepository.delete(member);
+        memberRepository.delete(memberRepository.findByIdOrThrow(memberId));
     }
 
     public List<MemberFindDto> findAllMembers() {

--- a/week2/practice/src/main/java/org/sopt/practice/service/MemberService.java
+++ b/week2/practice/src/main/java/org/sopt/practice/service/MemberService.java
@@ -41,8 +41,7 @@ public class MemberService {
     }
 
     public List<MemberFindDto> findAllMembers() {
-        List<Member> members = memberRepository.findAll();
-        return members.stream()
+        return memberRepository.findAll().stream()
                 .map(MemberFindDto::of)
                 .collect(Collectors.toList());
     }

--- a/week2/practice/src/main/java/org/sopt/practice/service/dto/MemberCreateDto.java
+++ b/week2/practice/src/main/java/org/sopt/practice/service/dto/MemberCreateDto.java
@@ -1,0 +1,11 @@
+package org.sopt.practice.service.dto;
+
+import org.sopt.practice.domain.Part;
+
+public record MemberCreateDto(
+        String name,
+        Part part,
+        int age
+) {
+
+}

--- a/week2/practice/src/main/java/org/sopt/practice/service/dto/MemberFindDto.java
+++ b/week2/practice/src/main/java/org/sopt/practice/service/dto/MemberFindDto.java
@@ -1,0 +1,20 @@
+package org.sopt.practice.service.dto;
+
+import org.sopt.practice.domain.Member;
+import org.sopt.practice.domain.Part;
+
+public record MemberFindDto(
+        Long id,
+        String name,
+        Part part,
+        int age
+) {
+
+    public static MemberFindDto of(Member member) {
+        return new MemberFindDto(
+                member.getId(),
+                member.getName(),
+                member.getPart(),
+                member.getAge());
+    }
+}

--- a/week2/practice/src/test/java/org/sopt/practice/controller/MemberControllerTest.java
+++ b/week2/practice/src/test/java/org/sopt/practice/controller/MemberControllerTest.java
@@ -1,0 +1,52 @@
+package org.sopt.practice.controller;
+
+import io.restassured.RestAssured;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.sopt.practice.domain.Part;
+import org.sopt.practice.repository.MemberRepository;
+import org.sopt.practice.service.MemberService;
+import org.sopt.practice.service.dto.MemberCreateDto;
+import org.sopt.practice.settings.ApiTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+public class MemberControllerTest extends ApiTest {
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Nested //중첩 테스트를 진행할 수 있게 하는 테스트
+    @DisplayName("멤버 생성 테스트")
+    public class CreateMember {
+
+        @Test
+        @DisplayName("요청 성공 케이스")
+        public void createMemberSuccess() throws Exception {
+            //given
+            final var request = new MemberCreateDto(
+                    "김채원",
+                    Part.SERVER,
+                    24);
+
+            //when
+            final var response = RestAssured
+                    .given()
+                    .log().all()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(request)
+                    .when()
+                    .post("/api/v1/member")
+                    .then().log().all().extract();
+
+            //then
+            Assertions.assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+        }
+    }
+}

--- a/week2/practice/src/test/java/org/sopt/practice/settings/ApiTest.java
+++ b/week2/practice/src/test/java/org/sopt/practice/settings/ApiTest.java
@@ -1,0 +1,18 @@
+package org.sopt.practice.settings;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class ApiTest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach //각 테스트 진행 전 실행
+    void setUp() {
+        RestAssured.port = port;
+    }
+}


### PR DESCRIPTION
## 과제 내용 📚
- **@RequestMapping("/api/v1/member") -> @RequestMapping("/api/v1/members")으로 변경하였습니다.**

![스크린샷 2024-04-16 오후 3 47 58](https://github.com/NOW-SOPT-SERVER/chaewonni/assets/113420297/bf5d5289-e163-493b-a9c4-0b8ba18d7797)
- **기존의 MemberFindDto record에 id 필드를 추가하여, Member 객체의 id 값을 포함시켰습니다.**

![스크린샷 2024-04-16 오후 3 48 08](https://github.com/NOW-SOPT-SERVER/chaewonni/assets/113420297/4ffdefe6-c083-4d1f-8165-07a2cdaf0986)

- **등록한 모든 멤버가 List로 반환되는 API를 구현하였습니다.**
### MemberController
```java
    @GetMapping
    public ResponseEntity<List<MemberFindDto>> findAllMembers() {
        return ResponseEntity.ok(memberService.findAllMembers());
    }
```
### MemberService
```java
    public List<MemberFindDto> findAllMembers() {
        List<Member> members = memberRepository.findAll();
        return members.stream()
                .map(MemberFindDto::of)
                .collect(Collectors.toList());
    }
```

- **멤버 등록, 멤버 조회, 멤버 삭제, 멤버 전체 조회 API 명세서를 작성하였습니다.**
  [API 명세서 바로가기](https://tidal-measure-df0.notion.site/API-71e6070dfb6448a9a257fce83d547d84?pvs=4)

## 연관 이슈 📌
close #2
