### PR TITLE
[feat] 3차 세미나 과제

### DIFF
--- a/week3/practice/build.gradle
+++ b/week3/practice/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.3'
 
 	testImplementation 'io.rest-assured:rest-assured'

--- a/week3/practice/src/main/java/org/sopt/practice/common/GlobalExceptionHandler.java
+++ b/week3/practice/src/main/java/org/sopt/practice/common/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package org.sopt.practice.common;
 
 import org.sopt.practice.common.dto.ErrorResponse;
+import org.sopt.practice.exception.ForbiddenException;
 import org.sopt.practice.exception.NotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,5 +22,10 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(NotFoundException.class)
     protected ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException e) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse.of(HttpStatus.NOT_FOUND.value(), e.getMessage()));
+    }
+
+    @ExceptionHandler(ForbiddenException.class)
+    protected ResponseEntity<ErrorResponse> handleForbiddenException(ForbiddenException e) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ErrorResponse.of(HttpStatus.FORBIDDEN.value(), e.getMessage()));
     }
 }

--- a/week3/practice/src/main/java/org/sopt/practice/common/GlobalExceptionHandler.java
+++ b/week3/practice/src/main/java/org/sopt/practice/common/GlobalExceptionHandler.java
@@ -1,0 +1,25 @@
+package org.sopt.practice.common;
+
+import org.sopt.practice.common.dto.ErrorResponse;
+import org.sopt.practice.exception.NotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Objects;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(), Objects.requireNonNull(e.getBindingResult().getFieldError().getDefaultMessage())));
+    } //메세지가 없을 수도 있으니 Objects
+
+    @ExceptionHandler(NotFoundException.class)
+    protected ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse.of(HttpStatus.NOT_FOUND.value(), e.getMessage()));
+    }
+}

--- a/week3/practice/src/main/java/org/sopt/practice/common/dto/ErrorMessage.java
+++ b/week3/practice/src/main/java/org/sopt/practice/common/dto/ErrorMessage.java
@@ -1,0 +1,16 @@
+package org.sopt.practice.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 사용자가 존재하지 않습ㄴ디ㅏ."),
+    BLOG_NOT_FOUND(HttpStatus.NOT_FOUND.value(),"ID에 해당하는 블로그가 존재하지 않습니다");
+    ;
+    private final int status;
+
+    private final String message;
+}

--- a/week3/practice/src/main/java/org/sopt/practice/common/dto/ErrorMessage.java
+++ b/week3/practice/src/main/java/org/sopt/practice/common/dto/ErrorMessage.java
@@ -7,8 +7,12 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorMessage {
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 사용자가 존재하지 않습ㄴ디ㅏ."),
-    BLOG_NOT_FOUND(HttpStatus.NOT_FOUND.value(),"ID에 해당하는 블로그가 존재하지 않습니다");
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 사용자가 존재하지 않습니다."),
+    BLOG_NOT_FOUND(HttpStatus.NOT_FOUND.value(),"ID에 해당하는 블로그가 존재하지 않습니다."),
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 포스트가 존재하지 않습니다."),
+
+    UNAUTHORIZED_MEMBER_ACCESS(HttpStatus.FORBIDDEN.value(), "이 멤버는 해당 블로그에 대한 접근 권한이 없습니다.")
+
     ;
     private final int status;
 

--- a/week3/practice/src/main/java/org/sopt/practice/common/dto/ErrorMessage.java
+++ b/week3/practice/src/main/java/org/sopt/practice/common/dto/ErrorMessage.java
@@ -11,7 +11,7 @@ public enum ErrorMessage {
     BLOG_NOT_FOUND(HttpStatus.NOT_FOUND.value(),"ID에 해당하는 블로그가 존재하지 않습니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 포스트가 존재하지 않습니다."),
 
-    UNAUTHORIZED_MEMBER_ACCESS(HttpStatus.FORBIDDEN.value(), "이 멤버는 해당 블로그에 대한 접근 권한이 없습니다.")
+    FORBIDDEN_MEMBER_ACCESS(HttpStatus.FORBIDDEN.value(), "이 멤버는 해당 블로그에 대한 접근 권한이 없습니다.")
 
     ;
     private final int status;

--- a/week3/practice/src/main/java/org/sopt/practice/common/dto/ErrorResponse.java
+++ b/week3/practice/src/main/java/org/sopt/practice/common/dto/ErrorResponse.java
@@ -1,0 +1,14 @@
+package org.sopt.practice.common.dto;
+
+public record ErrorResponse(
+        int status,
+        String message
+) {
+    public static ErrorResponse of(int status, String message) {
+        return new ErrorResponse(status, message);
+    }
+
+    public static ErrorResponse of(ErrorMessage errorMessage) {
+        return new ErrorResponse(errorMessage.getStatus(), errorMessage.getMessage());
+    }
+}

--- a/week3/practice/src/main/java/org/sopt/practice/common/dto/SuccessMessage.java
+++ b/week3/practice/src/main/java/org/sopt/practice/common/dto/SuccessMessage.java
@@ -1,0 +1,15 @@
+package org.sopt.practice.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum SuccessMessage {
+
+    BLOG_CREATE_SUCCESS(HttpStatus.CREATED.value(),"블로그 생성이 완료되었습니다.");
+
+    private final int status;
+    private final String message;
+}

--- a/week3/practice/src/main/java/org/sopt/practice/common/dto/SuccessMessage.java
+++ b/week3/practice/src/main/java/org/sopt/practice/common/dto/SuccessMessage.java
@@ -8,7 +8,10 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum SuccessMessage {
 
-    BLOG_CREATE_SUCCESS(HttpStatus.CREATED.value(),"블로그 생성이 완료되었습니다.");
+    BLOG_CREATE_SUCCESS(HttpStatus.CREATED.value(),"블로그 생성이 완료되었습니다."),
+    POST_CREATE_SUCCESS(HttpStatus.CREATED.value(),"게시글 생성이 완료되었습니다."),
+
+    POST_FIND_SUCCESS(HttpStatus.OK.value(), "게시글 찾기가 완료되었습니다.");
 
     private final int status;
     private final String message;

--- a/week3/practice/src/main/java/org/sopt/practice/common/dto/SuccessStatusResponse.java
+++ b/week3/practice/src/main/java/org/sopt/practice/common/dto/SuccessStatusResponse.java
@@ -1,0 +1,13 @@
+package org.sopt.practice.common.dto;
+
+import lombok.Getter;
+
+public record SuccessStatusResponse(
+        int status,
+        String message
+) {
+
+    public static SuccessStatusResponse of(SuccessMessage successMessage) {
+        return new SuccessStatusResponse(successMessage.getStatus(),successMessage.getMessage());
+    }
+}

--- a/week3/practice/src/main/java/org/sopt/practice/common/dto/SuccessStatusResponse.java
+++ b/week3/practice/src/main/java/org/sopt/practice/common/dto/SuccessStatusResponse.java
@@ -1,13 +1,20 @@
 package org.sopt.practice.common.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 
-public record SuccessStatusResponse(
+public record SuccessStatusResponse<T>(
         int status,
-        String message
+        String message,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        T data
 ) {
 
-    public static SuccessStatusResponse of(SuccessMessage successMessage) {
-        return new SuccessStatusResponse(successMessage.getStatus(),successMessage.getMessage());
+    public static SuccessStatusResponse<Void> of(SuccessMessage successMessage) {
+        return new SuccessStatusResponse<Void>(successMessage.getStatus(),successMessage.getMessage(), null);
+    }
+
+    public static <T> SuccessStatusResponse<T> of(SuccessMessage successMessage, T data) {
+        return new SuccessStatusResponse<T>(successMessage.getStatus(),successMessage.getMessage(),data);
     }
 }

--- a/week3/practice/src/main/java/org/sopt/practice/config/JpaAuditingConfig.java
+++ b/week3/practice/src/main/java/org/sopt/practice/config/JpaAuditingConfig.java
@@ -1,0 +1,10 @@
+package org.sopt.practice.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing //JPA가 엔티티를 감시할 수 있게 해줌
+public class JpaAuditingConfig {
+
+}

--- a/week3/practice/src/main/java/org/sopt/practice/controller/BlogController.java
+++ b/week3/practice/src/main/java/org/sopt/practice/controller/BlogController.java
@@ -1,0 +1,39 @@
+package org.sopt.practice.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.sopt.practice.common.dto.SuccessMessage;
+import org.sopt.practice.common.dto.SuccessStatusResponse;
+import org.sopt.practice.service.BlogService;
+import org.sopt.practice.service.dto.BlogCreateRequest;
+import org.sopt.practice.service.dto.BlogTitleUpdateRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class BlogController {
+
+    private final BlogService blogService;
+
+    @PostMapping("/blog")
+    public ResponseEntity<SuccessStatusResponse> createBlog(
+            @RequestHeader Long memberId,
+            @RequestBody BlogCreateRequest blogCreateRequest) {
+        return ResponseEntity.status(HttpStatus.CREATED).header(
+                        "Location",
+                        blogService.create(memberId, blogCreateRequest))
+                .body(SuccessStatusResponse.of(SuccessMessage.BLOG_CREATE_SUCCESS));
+    }
+
+    @PatchMapping("/blog/{blogId}/title")
+    public ResponseEntity updateBlogTitle(
+            @PathVariable Long blogId,
+            @Valid @RequestBody BlogTitleUpdateRequest blogTitleUpdateRequest
+    ) {
+        blogService.updateTitle(blogId, blogTitleUpdateRequest);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/week3/practice/src/main/java/org/sopt/practice/controller/PostController.java
+++ b/week3/practice/src/main/java/org/sopt/practice/controller/PostController.java
@@ -1,0 +1,48 @@
+package org.sopt.practice.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.sopt.practice.common.dto.SuccessMessage;
+import org.sopt.practice.common.dto.SuccessStatusResponse;
+import org.sopt.practice.service.PostService;
+import org.sopt.practice.service.dto.PostCreateRequest;
+import org.sopt.practice.service.dto.PostFindAllDto;
+import org.sopt.practice.service.dto.PostFindDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class PostController {
+
+    private final PostService postService;
+
+    @PostMapping("/posts")
+    public ResponseEntity<SuccessStatusResponse> createPost(
+            @RequestHeader Long memberId,
+            @RequestHeader Long blogId,
+            @Valid @RequestBody PostCreateRequest postCreateRequest) {
+        return ResponseEntity.status(HttpStatus.CREATED).header(
+                "Location",
+                postService.create(memberId, blogId, postCreateRequest))
+                .body(SuccessStatusResponse.of(SuccessMessage.POST_CREATE_SUCCESS));
+    }
+
+    @GetMapping("/posts/{postId}")
+    public ResponseEntity<SuccessStatusResponse<PostFindDto>> findPost(@PathVariable Long postId) {
+        return ResponseEntity.status(HttpStatus.OK).body(SuccessStatusResponse.of(
+                SuccessMessage.POST_FIND_SUCCESS,
+                postService.findPostById(postId)));
+    }
+
+    @GetMapping("/posts")
+    public ResponseEntity<SuccessStatusResponse<List<PostFindAllDto>>> findPosts() {
+        return ResponseEntity.status(HttpStatus.OK).body(SuccessStatusResponse.of(
+                SuccessMessage.POST_FIND_SUCCESS,
+                postService.findAllPosts()));
+    }
+}

--- a/week3/practice/src/main/java/org/sopt/practice/domain/BaseTimeEntity.java
+++ b/week3/practice/src/main/java/org/sopt/practice/domain/BaseTimeEntity.java
@@ -1,0 +1,23 @@
+package org.sopt.practice.domain;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+}

--- a/week3/practice/src/main/java/org/sopt/practice/domain/Blog.java
+++ b/week3/practice/src/main/java/org/sopt/practice/domain/Blog.java
@@ -1,0 +1,44 @@
+package org.sopt.practice.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.practice.service.dto.BlogCreateRequest;
+import org.sopt.practice.service.dto.BlogTitleUpdateRequest;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Blog extends BaseTimeEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @Column(length = 200)
+    private String title;
+
+    private String description;
+
+    private Blog(Member member, String title, String description) {
+        this.member = member;
+        this.title = title;
+        this.description = description;
+    }
+
+    public static Blog create(
+            Member member,
+            String title,
+            String description
+    ) {
+        return new Blog(member, title, description);
+    }
+
+    public void patch(BlogTitleUpdateRequest blogTitleUpdateRequest) {
+        if(this.title != blogTitleUpdateRequest.title())
+            this.title = blogTitleUpdateRequest.title();
+    }
+}

--- a/week3/practice/src/main/java/org/sopt/practice/domain/Post.java
+++ b/week3/practice/src/main/java/org/sopt/practice/domain/Post.java
@@ -1,0 +1,22 @@
+package org.sopt.practice.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Post extends BaseTimeEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Blog blog;
+}

--- a/week3/practice/src/main/java/org/sopt/practice/domain/Post.java
+++ b/week3/practice/src/main/java/org/sopt/practice/domain/Post.java
@@ -19,4 +19,16 @@ public class Post extends BaseTimeEntity{
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Blog blog;
+
+    private Post(Blog blog, String title, String content) {
+        this.blog = blog;
+        this.title = title;
+        this.content = content;
+    }
+
+    public static Post create(
+            Blog blog, String title, String content
+    ) {
+        return new Post(blog, title, content);
+    }
 }

--- a/week3/practice/src/main/java/org/sopt/practice/exception/BusinessException.java
+++ b/week3/practice/src/main/java/org/sopt/practice/exception/BusinessException.java
@@ -1,0 +1,11 @@
+package org.sopt.practice.exception;
+
+import org.sopt.practice.common.dto.ErrorMessage;
+
+public class BusinessException extends RuntimeException {
+    private ErrorMessage errorMessage;
+    public BusinessException(ErrorMessage errorMessage) {
+        super(errorMessage.getMessage());
+        this.errorMessage = errorMessage;
+    }
+}

--- a/week3/practice/src/main/java/org/sopt/practice/exception/ForbiddenException.java
+++ b/week3/practice/src/main/java/org/sopt/practice/exception/ForbiddenException.java
@@ -2,8 +2,8 @@ package org.sopt.practice.exception;
 
 import org.sopt.practice.common.dto.ErrorMessage;
 
-public class UnauthorizedException extends BusinessException{
-    public UnauthorizedException(ErrorMessage errorMessage) {
+public class ForbiddenException extends BusinessException{
+    public ForbiddenException(ErrorMessage errorMessage) {
         super(errorMessage);
     }
 }

--- a/week3/practice/src/main/java/org/sopt/practice/exception/NotFoundException.java
+++ b/week3/practice/src/main/java/org/sopt/practice/exception/NotFoundException.java
@@ -1,0 +1,9 @@
+package org.sopt.practice.exception;
+
+import org.sopt.practice.common.dto.ErrorMessage;
+
+public class NotFoundException extends BusinessException {
+    public NotFoundException(ErrorMessage errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/week3/practice/src/main/java/org/sopt/practice/exception/UnauthorizedException.java
+++ b/week3/practice/src/main/java/org/sopt/practice/exception/UnauthorizedException.java
@@ -1,0 +1,9 @@
+package org.sopt.practice.exception;
+
+import org.sopt.practice.common.dto.ErrorMessage;
+
+public class UnauthorizedException extends BusinessException{
+    public UnauthorizedException(ErrorMessage errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/week3/practice/src/main/java/org/sopt/practice/repository/BlogRepository.java
+++ b/week3/practice/src/main/java/org/sopt/practice/repository/BlogRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.practice.repository;
+
+import org.sopt.practice.domain.Blog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BlogRepository extends JpaRepository<Blog, Long> {
+}

--- a/week3/practice/src/main/java/org/sopt/practice/repository/MemberRepository.java
+++ b/week3/practice/src/main/java/org/sopt/practice/repository/MemberRepository.java
@@ -1,14 +1,16 @@
 package org.sopt.practice.repository;
 
 import jakarta.persistence.EntityNotFoundException;
+import org.sopt.practice.common.dto.ErrorMessage;
 import org.sopt.practice.domain.Member;
+import org.sopt.practice.exception.NotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     default Member findByIdOrThrow(Long id) {
         return findById(id).orElseThrow(
-                () -> new EntityNotFoundException("ID에 해당하는 사용자가 존재하지 않습니다.")
+                () -> new NotFoundException(ErrorMessage.MEMBER_NOT_FOUND)
         );
     }
 }

--- a/week3/practice/src/main/java/org/sopt/practice/repository/PostRepository.java
+++ b/week3/practice/src/main/java/org/sopt/practice/repository/PostRepository.java
@@ -1,0 +1,15 @@
+package org.sopt.practice.repository;
+
+import org.sopt.practice.common.dto.ErrorMessage;
+import org.sopt.practice.domain.Post;
+import org.sopt.practice.exception.NotFoundException;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+    default Post findByIdOrThrow(Long id) {
+        return findById(id).orElseThrow(
+                () -> new NotFoundException(ErrorMessage.POST_NOT_FOUND)
+        );
+    }
+}

--- a/week3/practice/src/main/java/org/sopt/practice/service/BlogService.java
+++ b/week3/practice/src/main/java/org/sopt/practice/service/BlogService.java
@@ -1,0 +1,36 @@
+package org.sopt.practice.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.sopt.practice.common.dto.ErrorMessage;
+import org.sopt.practice.domain.Blog;
+import org.sopt.practice.domain.Member;
+import org.sopt.practice.exception.NotFoundException;
+import org.sopt.practice.repository.BlogRepository;
+import org.sopt.practice.service.dto.BlogCreateRequest;
+import org.sopt.practice.service.dto.BlogTitleUpdateRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BlogService {
+
+    private final BlogRepository blogRepository;
+    private final MemberService memberService;
+
+
+    public String create(Long memberId, BlogCreateRequest blogCreateRequest) {
+        //member찾기
+        Member member = memberService.findById(memberId);
+        Blog blog = blogRepository.save(Blog.create(member, blogCreateRequest.title(), blogCreateRequest.description()));
+        return blog.getId().toString();
+    }
+
+    @Transactional
+    public void updateTitle(Long blogId, BlogTitleUpdateRequest newTitle) {
+        Blog target = blogRepository.findById(blogId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.BLOG_NOT_FOUND));
+        target.patch(newTitle);
+        blogRepository.save(target);
+    }
+}

--- a/week3/practice/src/main/java/org/sopt/practice/service/MemberService.java
+++ b/week3/practice/src/main/java/org/sopt/practice/service/MemberService.java
@@ -3,7 +3,9 @@ package org.sopt.practice.service;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.sopt.practice.common.dto.ErrorMessage;
 import org.sopt.practice.domain.Member;
+import org.sopt.practice.exception.NotFoundException;
 import org.sopt.practice.repository.MemberRepository;
 import org.sopt.practice.service.dto.MemberCreateDto;
 import org.sopt.practice.service.dto.MemberFindDto;
@@ -25,6 +27,16 @@ public class MemberService {
         Member member = Member.create(memberCreate.name(), memberCreate.part(), memberCreate.age());
         memberRepository.save(member);
         return member.getId().toString();
+    }
+
+//    public Member findById(Long memberId) {
+//        return memberRepository.findByIdOrThrow(memberId);
+//    }
+
+    public Member findById(Long memberId) {
+        return memberRepository.findById(memberId).orElseThrow(
+                () -> new NotFoundException(ErrorMessage.MEMBER_NOT_FOUND)
+        );
     }
 
     public MemberFindDto findMemberById(Long memberId) {

--- a/week3/practice/src/main/java/org/sopt/practice/service/MemberService.java
+++ b/week3/practice/src/main/java/org/sopt/practice/service/MemberService.java
@@ -29,14 +29,8 @@ public class MemberService {
         return member.getId().toString();
     }
 
-//    public Member findById(Long memberId) {
-//        return memberRepository.findByIdOrThrow(memberId);
-//    }
-
     public Member findById(Long memberId) {
-        return memberRepository.findById(memberId).orElseThrow(
-                () -> new NotFoundException(ErrorMessage.MEMBER_NOT_FOUND)
-        );
+        return memberRepository.findByIdOrThrow(memberId);
     }
 
     public MemberFindDto findMemberById(Long memberId) {

--- a/week3/practice/src/main/java/org/sopt/practice/service/PostService.java
+++ b/week3/practice/src/main/java/org/sopt/practice/service/PostService.java
@@ -1,0 +1,57 @@
+package org.sopt.practice.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.practice.common.dto.ErrorMessage;
+import org.sopt.practice.domain.Blog;
+import org.sopt.practice.domain.Post;
+import org.sopt.practice.exception.NotFoundException;
+import org.sopt.practice.exception.UnauthorizedException;
+import org.sopt.practice.repository.BlogRepository;
+import org.sopt.practice.repository.PostRepository;
+import org.sopt.practice.service.dto.PostCreateRequest;
+import org.sopt.practice.service.dto.PostFindAllDto;
+import org.sopt.practice.service.dto.PostFindDto;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+    private final BlogRepository blogRepository;
+    private final PostRepository postRepository;
+
+    @Transactional
+    public String create(Long memberId, Long blogId, PostCreateRequest postCreateRequest) {
+
+        checkMemberMatchesBlog(memberId, blogId);
+
+        Blog blog = blogRepository.findById(blogId).orElseThrow(
+                () -> new NotFoundException(ErrorMessage.BLOG_NOT_FOUND)
+        );
+
+        Post post = postRepository.save(Post.create(blog, postCreateRequest.title(), postCreateRequest.content()));
+        return post.getId().toString();
+    }
+
+    private void checkMemberMatchesBlog(Long memberId, Long blogId) {
+        Blog blog = blogRepository.findById(blogId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.BLOG_NOT_FOUND));
+
+        if(!blog.getMember().getId().equals(memberId)) {
+            throw new UnauthorizedException(ErrorMessage.UNAUTHORIZED_MEMBER_ACCESS);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public PostFindDto findPostById(Long postId) {
+        return PostFindDto.of(postRepository.findByIdOrThrow(postId));
+    }
+
+    @Transactional(readOnly = true)
+    public List<PostFindAllDto> findAllPosts() {
+        return PostFindAllDto.listOf(postRepository.findAll());
+    }
+}

--- a/week3/practice/src/main/java/org/sopt/practice/service/PostService.java
+++ b/week3/practice/src/main/java/org/sopt/practice/service/PostService.java
@@ -5,7 +5,7 @@ import org.sopt.practice.common.dto.ErrorMessage;
 import org.sopt.practice.domain.Blog;
 import org.sopt.practice.domain.Post;
 import org.sopt.practice.exception.NotFoundException;
-import org.sopt.practice.exception.UnauthorizedException;
+import org.sopt.practice.exception.ForbiddenException;
 import org.sopt.practice.repository.BlogRepository;
 import org.sopt.practice.repository.PostRepository;
 import org.sopt.practice.service.dto.PostCreateRequest;
@@ -41,7 +41,7 @@ public class PostService {
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.BLOG_NOT_FOUND));
 
         if(!blog.getMember().getId().equals(memberId)) {
-            throw new UnauthorizedException(ErrorMessage.UNAUTHORIZED_MEMBER_ACCESS);
+            throw new ForbiddenException(ErrorMessage.FORBIDDEN_MEMBER_ACCESS);
         }
     }
 

--- a/week3/practice/src/main/java/org/sopt/practice/service/dto/BlogCreateRequest.java
+++ b/week3/practice/src/main/java/org/sopt/practice/service/dto/BlogCreateRequest.java
@@ -1,0 +1,7 @@
+package org.sopt.practice.service.dto;
+
+public record BlogCreateRequest(
+        String title,
+        String description
+) {
+}

--- a/week3/practice/src/main/java/org/sopt/practice/service/dto/BlogFindDto.java
+++ b/week3/practice/src/main/java/org/sopt/practice/service/dto/BlogFindDto.java
@@ -1,0 +1,17 @@
+package org.sopt.practice.service.dto;
+
+import org.sopt.practice.domain.Blog;
+
+public record BlogFindDto(
+        String title,
+        String description,
+        MemberFindDto member
+) {
+    public static BlogFindDto of(Blog blog) {
+        return new BlogFindDto(
+                blog.getTitle(),
+                blog.getDescription(),
+                MemberFindDto.of(blog.getMember())
+        );
+    }
+}

--- a/week3/practice/src/main/java/org/sopt/practice/service/dto/BlogTitleUpdateRequest.java
+++ b/week3/practice/src/main/java/org/sopt/practice/service/dto/BlogTitleUpdateRequest.java
@@ -1,0 +1,9 @@
+package org.sopt.practice.service.dto;
+
+import jakarta.validation.constraints.Size;
+
+public record BlogTitleUpdateRequest(
+        @Size(max = 10, message = "블로그 제목이 최대 글자 수(10자)를 초과했습니다.")
+        String title
+) {
+}

--- a/week3/practice/src/main/java/org/sopt/practice/service/dto/PostCreateRequest.java
+++ b/week3/practice/src/main/java/org/sopt/practice/service/dto/PostCreateRequest.java
@@ -1,0 +1,14 @@
+package org.sopt.practice.service.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record PostCreateRequest(
+        @NotBlank(message = "게시글 제목은 필수로 입력해야 합니다.")
+        @Size(max = 10, message = "게시글 제목이 최대 글자 수(10자)를 초과했습니다.")
+        String title,
+
+        @NotBlank(message = "게시글 내용은 필수로 입력해야 합니다.")
+        String content
+) {
+}

--- a/week3/practice/src/main/java/org/sopt/practice/service/dto/PostCreateRequest.java
+++ b/week3/practice/src/main/java/org/sopt/practice/service/dto/PostCreateRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.Size;
 
 public record PostCreateRequest(
         @NotBlank(message = "게시글 제목은 필수로 입력해야 합니다.")
-        @Size(max = 10, message = "게시글 제목이 최대 글자 수(10자)를 초과했습니다.")
+        @Size(max = 100, message = "게시글 제목이 최대 글자 수(100자)를 초과했습니다.")
         String title,
 
         @NotBlank(message = "게시글 내용은 필수로 입력해야 합니다.")

--- a/week3/practice/src/main/java/org/sopt/practice/service/dto/PostFindAllDto.java
+++ b/week3/practice/src/main/java/org/sopt/practice/service/dto/PostFindAllDto.java
@@ -1,0 +1,23 @@
+package org.sopt.practice.service.dto;
+
+import org.sopt.practice.domain.Blog;
+import org.sopt.practice.domain.Post;
+
+import java.util.List;
+
+public record PostFindAllDto(
+
+        Long id,
+        String title,
+        String content
+) {
+    public static List<PostFindAllDto> listOf(List<Post> posts) {
+        return posts
+                .stream()
+                .map(post -> new PostFindAllDto(
+                        post.getId(),
+                        post.getTitle(),
+                        post.getContent()
+                )).toList();
+    }
+}

--- a/week3/practice/src/main/java/org/sopt/practice/service/dto/PostFindDto.java
+++ b/week3/practice/src/main/java/org/sopt/practice/service/dto/PostFindDto.java
@@ -1,6 +1,5 @@
 package org.sopt.practice.service.dto;
 
-import org.sopt.practice.domain.Blog;
 import org.sopt.practice.domain.Post;
 
 public record PostFindDto(

--- a/week3/practice/src/main/java/org/sopt/practice/service/dto/PostFindDto.java
+++ b/week3/practice/src/main/java/org/sopt/practice/service/dto/PostFindDto.java
@@ -1,0 +1,18 @@
+package org.sopt.practice.service.dto;
+
+import org.sopt.practice.domain.Blog;
+import org.sopt.practice.domain.Post;
+
+public record PostFindDto(
+        String title,
+        String content,
+        BlogFindDto blog
+) {
+    public static PostFindDto of(Post post){
+        return new PostFindDto(
+                post.getTitle(),
+                post.getContent(),
+                BlogFindDto.of(post.getBlog())
+        );
+    }
+}

--- a/week3/practice/src/test/java/org/sopt/practice/controller/BlogControllerTest.java
+++ b/week3/practice/src/test/java/org/sopt/practice/controller/BlogControllerTest.java
@@ -1,0 +1,69 @@
+package org.sopt.practice.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.sopt.practice.repository.BlogRepository;
+import org.sopt.practice.repository.MemberRepository;
+import org.sopt.practice.service.BlogService;
+import org.sopt.practice.service.MemberService;
+import org.sopt.practice.service.dto.BlogCreateRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(BlogController.class) //SpringBootTest로 서버를 구동시키는 대신 Controller 계층만 테스트
+@AutoConfigureMockMvc //Spring Boot 테스트에서 MockMvc를 사용하기 위한 설정을 자동으로 제공하는 어노테이션
+public class BlogControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    /*
+    BlogRepository -> BlogService -> MemberService -> MemberRepository
+                                                                -> BlogRepository
+    */
+    @SpyBean
+    private BlogService blogService;
+
+    @SpyBean
+    private MemberService memberService;
+
+    @MockBean
+    private MemberRepository memberRepository;
+
+    @MockBean
+    private BlogRepository blogRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper; //생성하는 객체를 String JSON 배열로 바꾸기 위해 사용
+
+    @Nested
+    class createBlog {
+        @Test
+        @DisplayName("Blog 생성 실패 테스트")
+        public void createBlogFail() throws Exception {
+
+            //given
+            String request = objectMapper.writeValueAsString(new BlogCreateRequest("채원이네 블로그", "블로그입니다."));
+
+            //when
+            mockMvc.perform(
+                            post("/api/v1/blog")
+                                    .content(request).header("memberId", 1)
+                                    .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isNotFound()) //생성 실패 시나리오로 NotFound가 돌아오는 상황을 테스트
+                    .andDo(print()); // 끝난 후 모든 결과를 출력
+
+        }
+    }
+}


### PR DESCRIPTION
- closes #6  
- [API 명세서 바로가기](https://www.notion.so/API-5fd11d8eaa204be69cf9a3d49be8846c)
## 이 주의 과제

<!-- 이번 주에 구현한 API가 포함되어 있는 뷰와 API에 대한 설명을 적어주세요 -->
블로그에 대해 글을 작성하는 POST API와, GET API를 구현
- 게시글 작성 API 구현
- 게시글 단건조회 API 구현
- 게시글 전체조회 API 구현

### 요구사항 분석

<!-- 해당 API에 대한 요구사항(사용자 플로우)을/를 설명해주세요 -->
- memberId, blogId 를 header로 받아오고, 게시글 제목과 내용을 dto로 받아와 게시글을 생성합니다.
- 이 때, 게시글의 제목과 내용은 필수 입력값이며, 제목은 최대 100자입니다.
- 자신의 블로그가 아닌 곳에 글을 쓸 경우 FORBIDDEN 에러를 발생시킵니다.
- 생성된 게시글은 header에 memberId를 넣어 반환합니다.

- 게시글 조회는 단건 조회, 전체 조회로 이루어져있습니다.

## 구현 고민 사항

게시글 단건조회, 전체조회를 할 때 계속 No serializer found for class org.hibernate.proxy.pojo.bytebuddy.ByteBuddyInterceptor ..... 오류가 발생했는데, 찾아보니 이 오류는 데이터 직렬화 과정에서 발생한 문제로, Jackson이 Hibernate의 **지연 로딩(lazy loading)** 으로 인해 생성된 프록시 객체의 내부를 직렬화하려 할 때 발생한다는 것을 알게되었습니다...

``` java
public record PostFindDto(
        String title,
        String content,
        Blog blog
) {
    public static PostFindDto of(Post post){
        return new PostFindDto(
                post.getTitle(),
                post.getContent(),
               post.getBlog()
        );
    }
}
```

즉 PostFindDto에서 Blog 엔티티를 직접 사용했기 때문에, Jackson이 Hibernate의 프록시 객체와 지연 로딩된 데이터를 직렬화하려 하면서 오류가 발생한 것이었숩니다..

따라서 

```java
public record BlogFindDto(
        String title,
        String description,
        MemberFindDto member
) {
    public static BlogFindDto of(Blog blog) {
        return new BlogFindDto(
                blog.getTitle(),
                blog.getDescription(),
                MemberFindDto.of(blog.getMember())
        );
    }
}
```
블로그 조회 dto인 BlogFindDto를 만들어주고, 

```java
public record PostFindDto(
        String title,
        String content,
        BlogFindDto blog
) {
    public static PostFindDto of(Post post){
        return new PostFindDto(
                post.getTitle(),
                post.getContent(),
                BlogFindDto.of(post.getBlog())
        );
    }
}
```
PostFindDto에서 Blog 엔티티를 직접 사용하지 않고 BlogFindDto를 사용함으로써, Hibernate의 프록시 객체와 지연 로딩 문제를 회피하고, 필요한 데이터만을 간단한 구조로 직렬화할 수 있게 되어 에러가 해결되었습니다.

## 질문있어요!

- 자신의 블로그가 아닌 곳에 글을 쓸 경우 403 FORBIDDEN 에러를 발생시켰는데, 401 Unauthorized 에러와 어떤 차이가 있는지 궁금합니다.
- 게시글 단건 조회에서 게시글이 속한 블로그의 정보와 블로그를 소유한 멤버의 정보도 같이 반환했는데,
![스크린샷 2024-04-29 오후 6 15 18](https://github.com/NOW-SOPT-SERVER/chaewonni/assets/113420297/d719f899-827f-40e8-af74-551c3fe060cb)
게시글이 속한 블로그의 정보와 블로그를 소유한 멤버의 정보는 id 정도만 같이 반환하는게 좋을지 아니면 지금처럼 내용들도 같이 반환하는 게 좋을지 고민이 됩니다..!!
